### PR TITLE
Add interactive embedding map projection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ network
 numpy
 sentence-transformers
 scikit-learn
+plotly
+streamlit-plotly-events


### PR DESCRIPTION
## Summary
- compute PCA-based 2D projection of node embeddings
- add Embedding Map tab with selectable nodes and details
- include plotly and streamlit-plotly-events dependencies
- fix community coloring by guarding community detection and persisting checkbox state

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile 05-kg_semantic_explorer.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3636fbfc08325b1a96e37bcd9348a